### PR TITLE
Enforce strict mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "devDependencies": {},
   "scripts": {
-    "start": "node index.js",
+    "start": "node --use_strict index.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "Siddharth Vadgama <me@siddv.net>",

--- a/readme.md
+++ b/readme.md
@@ -11,5 +11,5 @@ Optional: change the `const timeout` in `index.js` to change the frequency
 
 `npm install`
 
-`npm run start` or `node index.js`
+`npm run start` or `node --use_strict index.js`
 


### PR DESCRIPTION
This prevents error "SyntaxError: Block-scoped declarations (let, const,function, class) not yet supported outside strict mode":

```
$ node index.js 
/home/adam/Slack-Emoji-Status-Changer/index.js:21
  let emoji = getRandomEmoji(),
  ^^^

SyntaxError: Block-scoped declarations (let, const, function, class) not yet supported outside strict mode
    at exports.runInThisContext (vm.js:53:16)
    at Module._compile (module.js:373:25)
    at Object.Module._extensions..js (module.js:416:10)
    at Module.load (module.js:343:32)
    at Function.Module._load (module.js:300:12)
    at Function.Module.runMain (module.js:441:10)
    at startup (node.js:139:18)
    at node.js:990:3
```